### PR TITLE
Custom Spawn Costs

### DIFF
--- a/ExtraEnemyCustomization/Configs/Customizations/SpawnCostCustomConfig.cs
+++ b/ExtraEnemyCustomization/Configs/Customizations/SpawnCostCustomConfig.cs
@@ -1,0 +1,19 @@
+﻿using EECustom.Customizations;
+using EECustom.Customizations.Shooters;
+using EECustom.Customizations.SpawnCost;
+using EECustom.CustomSettings.DTO;
+using System.Collections.Generic;
+
+namespace EECustom.Configs.Customizations
+{
+    public class SpawnCostCustomConfig : CustomizationConfig
+    {
+        public SpawnCostCustom[] SpawnCostCustom { get; set; } = new SpawnCostCustom[0];
+        public override EnemyCustomBase[] GetAllSettings()
+        {
+            var list = new List<EnemyCustomBase>();
+            list.AddRange(SpawnCostCustom);
+            return list.ToArray();
+        }
+    }
+}

--- a/ExtraEnemyCustomization/Customizations/SpawnCost/SpawnCostCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/SpawnCost/SpawnCostCustom.cs
@@ -1,4 +1,5 @@
-﻿using Enemies;
+﻿using Agents;
+using Enemies;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -18,7 +19,16 @@ namespace EECustom.Customizations.SpawnCost
         public override void Postspawn(EnemyAgent agent)
         {
             agent.m_enemyCost = SpawnCost;
-            LogDev($"Set Enemy Cost to {SpawnCost}!");
+            if (agent.AI.Mode == AgentMode.Agressive)
+            {
+                float delta = EnemyCostManager.Current.m_enemyTypeCosts[(int)agent.EnemyData.EnemyType] - SpawnCost;
+                EnemyCostManager.AddCost(-delta);
+                LogDev($"Decremented cost by {delta}!");
+            }
+            else
+            {
+                LogDev($"Set Enemy Cost to {SpawnCost}!");
+            }
         }
     }
 }

--- a/ExtraEnemyCustomization/Customizations/SpawnCost/SpawnCostCustom.cs
+++ b/ExtraEnemyCustomization/Customizations/SpawnCost/SpawnCostCustom.cs
@@ -1,0 +1,24 @@
+﻿using Enemies;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EECustom.Customizations.SpawnCost
+{
+    public class SpawnCostCustom : EnemyCustomBase
+    {
+        public float SpawnCost { get; set; } = 0.0f;
+        public override string GetProcessName()
+        {
+            return "SpawnCost";
+        }
+
+        public override bool HasPostspawnBody => true;
+
+        public override void Postspawn(EnemyAgent agent)
+        {
+            agent.m_enemyCost = SpawnCost;
+            LogDev($"Set Enemy Cost to {SpawnCost}!");
+        }
+    }
+}

--- a/ExtraEnemyCustomization/Managers/ConfigManager.cs
+++ b/ExtraEnemyCustomization/Managers/ConfigManager.cs
@@ -51,6 +51,9 @@ namespace EECustom.Managers
                         CustomScoutWaveManager.AddTargetSetting(scoutWaveConfig.TargetSettings);
                         CustomScoutWaveManager.AddWaveSetting(scoutWaveConfig.WaveSettings);
                     }
+                    Logger.Debug("Loading SpawnCost.json...");
+                    if (TryLoadConfig(BasePath, "SpawnCost.json", out SpawnCostCustomConfig spawnCostConfig))
+                        Current.SpawnCostCustom = spawnCostConfig;
                 }
                 catch (Exception e)
                 {
@@ -97,6 +100,7 @@ namespace EECustom.Managers
         public ProjectileCustomConfig ProjectileCustom { get; private set; } = new ProjectileCustomConfig();
         public TentacleCustomConfig TentacleCustom { get; private set; } = new TentacleCustomConfig();
         public DetectionCustomConfig DetectionCustom { get; private set; } = new DetectionCustomConfig();
+        public SpawnCostCustomConfig SpawnCostCustom { get; private set; } = new SpawnCostCustomConfig();
 
         private readonly List<EnemyCustomBase> _CustomizationBuffer = new List<EnemyCustomBase>();
 
@@ -108,6 +112,7 @@ namespace EECustom.Managers
             _CustomizationBuffer.AddRange(ProjectileCustom.GetAllSettings());
             _CustomizationBuffer.AddRange(TentacleCustom.GetAllSettings());
             _CustomizationBuffer.AddRange(DetectionCustom.GetAllSettings());
+            _CustomizationBuffer.AddRange(SpawnCostCustom.GetAllSettings());
             foreach (var custom in _CustomizationBuffer)
             {
                 custom.Initialize();


### PR DESCRIPTION
## Summary
Creates the option to edit enemy agents' spawn cost for survival waves, so the cap of 25 can be reached at a different pace with each enemy.
## Example SpawnCost.json
```
{
	"SpawnCostCustom": [
		{
			"Enabled": true,
			"DebugName": "StrikerCustomTest",
			"Target": {
				"Mode": "NameContains",
				"persistentIDs": [],
				"nameParam": "Striker",
				"nameIgnoreCase": true
			},
			"SpawnCost": 0.2
		}
	]
}
```